### PR TITLE
Jacob's Solution

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,36 @@
+## WaterLogging
+
+## Managed Objects
+`Goal`: I designed goals so that they can have a start and end date. If you update your goal, and the goal's start date is different than today, it will set the current goals' end date to yesterday and create a new goal with a new start date of today.  The idea behind this strategy was to make it so that if other features were added to the app that required us to see how many days a user met their daily goal, we'd want the check to reflect the goal of those specific days. There are some checks to make sure that there can't be two goals with the same start date. 
+
+`Fluid`: I added a `Fluid` entity as part of the enhancement for tracking different types of intake and calculating the total water consumption based on how much water makes up each fluid.  There is currently no methods for adding new `Fluid`s, but the necessary fluids for the enhancement are seeded when the core data stack is configured. 
+
+`Intake`: Intake is used to track the individual entries for a user's fluid consumption.  The intake has a date, amount, volume, and a waterVolume.  In order to make using the database to run various mathematical operations, I figured it'd be better to store the computed water volume since that value wouldn't change, but would need to be calculated every time it was needed and the calculation would have to reach into the `Fluid` relationship
+
+The `Intake` has no direct relationship to a `Goal`. You can add an `Intake` without having set a `Goal` at all.  If we wanted to pull a goal for a specific intake or get all intakes of a specific goal, I think we could use a `FetchedProperty` for that, currently you'd have to pull those values by using dates.
+
+The `Intake` has a required relationship to a `Fluid`.  Technically this relationship doesn't need to be required in the current state of the app because we are calculating the `waterVolume` when we create a new `Intake`, but thinking ahead to other features that might get added in app like this, we might want to see percentage of intakes that were of a specific fluid and the relationship would be needed there.
+
+## Persistence
+For simplicity, I made a singleton (_gasp_) to manage the CoreDataStack. The container can be configured separately for unit testing and the main app.
+There is an extension to seed the database with some `Fluid`s as described in the enhancement for keeping track of different types of drinks.
+
+## Service
+There is a `Service` for each of the Managed Objects described above. The services are instantiated as needed by the view controllers that use them. Each service has a protocol defining the methods and a concrete implementation coupled to core data. The services reaches into the `CoreDataStack` to execute fetch requests as well as basic CRUD on the entities.
+
+## Track
+In the Track ViewController, I added a couple of alerts to allow user entry as well as show some feedback when the user tries to add an intake or update a goal.  There is a simple `BannerNotificationView` that will flash green or red with a message depending if the operation was a success or failure so there is some feedback to the user when submitting the forms.
+
+For updating a goal there is a UIAlertController with a textfield to enter the new value.
+
+For adding an intake I used another UIAlertController and swizzled it give me enough room to add a picker in the view.  This allows the user to select a Fluid and enter the number of ounces consumed. Any respectable dev would have done this by presenting a view controller, but I was trying to be mindful of the allotted time. The other UX I had started for selecting a liquid seemed odd as it was disjointed from entering the number of ounces, so I combined that here. 
+
+## Visualize
+For the Visualization ViewController I updated the data to render every time the user goes to that tab.
+The UI will support a user not having set a daily goal and will instead just show the total number of ounces consumed that day.
+I also added a circular progress bar for some extra flair. 
+
+## Testing
+There are a handful of tests written focused around the service layer.  With more time I would have added more for the ViewControllers to make sure things like the text on the visualization tab was correct and created some other doubles to ensure things like the notification messages were correct.
+
+The CoreDataStack persistent container is setup and torn down for each test.

--- a/WaterLogging.xcodeproj/project.pbxproj
+++ b/WaterLogging.xcodeproj/project.pbxproj
@@ -7,6 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		160FA67724BA750B00AE21F0 /* IntakeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160FA67624BA750B00AE21F0 /* IntakeServiceTests.swift */; };
+		160FA67A24BA7D5E00AE21F0 /* BannerNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160FA67924BA7D5E00AE21F0 /* BannerNotificationView.swift */; };
+		160FA67C24BA873600AE21F0 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160FA67B24BA873600AE21F0 /* CircularProgressView.swift */; };
+		160FA67E24BCB93D00AE21F0 /* CoreDataStack+Seedable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160FA67D24BCB93D00AE21F0 /* CoreDataStack+Seedable.swift */; };
+		16A8F32B24BA3632000EEB6A /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F32A24BA3632000EEB6A /* CoreDataStack.swift */; };
+		16A8F33424BA382D000EEB6A /* Intake+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F32E24BA382D000EEB6A /* Intake+CoreDataClass.swift */; };
+		16A8F33524BA382D000EEB6A /* Intake+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F32F24BA382D000EEB6A /* Intake+CoreDataProperties.swift */; };
+		16A8F33624BA382D000EEB6A /* Fluid+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F33024BA382D000EEB6A /* Fluid+CoreDataClass.swift */; };
+		16A8F33724BA382D000EEB6A /* Fluid+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F33124BA382D000EEB6A /* Fluid+CoreDataProperties.swift */; };
+		16A8F33824BA382D000EEB6A /* Goal+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F33224BA382D000EEB6A /* Goal+CoreDataClass.swift */; };
+		16A8F33924BA382D000EEB6A /* Goal+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F33324BA382D000EEB6A /* Goal+CoreDataProperties.swift */; };
+		16A8F33B24BA399F000EEB6A /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F33A24BA399F000EEB6A /* UserDefaults.swift */; };
+		16A8F34024BA3E67000EEB6A /* MockPersistentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F33F24BA3E67000EEB6A /* MockPersistentContainer.swift */; };
+		16A8F34224BA4608000EEB6A /* FluidService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F34124BA4608000EEB6A /* FluidService.swift */; };
+		16A8F34624BA48B0000EEB6A /* FluidServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F34524BA48B0000EEB6A /* FluidServiceTests.swift */; };
+		16A8F34824BA4E54000EEB6A /* GoalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F34724BA4E54000EEB6A /* GoalService.swift */; };
+		16A8F34A24BA4E62000EEB6A /* IntakeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F34924BA4E62000EEB6A /* IntakeService.swift */; };
+		16A8F34C24BA5785000EEB6A /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F34B24BA5785000EEB6A /* Date.swift */; };
+		16A8F34E24BA5FFB000EEB6A /* GoalServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A8F34D24BA5FFB000EEB6A /* GoalServiceTests.swift */; };
 		B31AA1C824734EAB007708F4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B31AA1C724734EAB007708F4 /* AppDelegate.swift */; };
 		B31AA1CA24734EAB007708F4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B31AA1C924734EAB007708F4 /* SceneDelegate.swift */; };
 		B31AA1CF24734EAB007708F4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B31AA1CD24734EAB007708F4 /* Main.storyboard */; };
@@ -30,6 +49,25 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		160FA67624BA750B00AE21F0 /* IntakeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntakeServiceTests.swift; sourceTree = "<group>"; };
+		160FA67924BA7D5E00AE21F0 /* BannerNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerNotificationView.swift; sourceTree = "<group>"; };
+		160FA67B24BA873600AE21F0 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
+		160FA67D24BCB93D00AE21F0 /* CoreDataStack+Seedable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataStack+Seedable.swift"; sourceTree = "<group>"; };
+		16A8F32A24BA3632000EEB6A /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
+		16A8F32E24BA382D000EEB6A /* Intake+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Intake+CoreDataClass.swift"; sourceTree = "<group>"; };
+		16A8F32F24BA382D000EEB6A /* Intake+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Intake+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		16A8F33024BA382D000EEB6A /* Fluid+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fluid+CoreDataClass.swift"; sourceTree = "<group>"; };
+		16A8F33124BA382D000EEB6A /* Fluid+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fluid+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		16A8F33224BA382D000EEB6A /* Goal+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Goal+CoreDataClass.swift"; sourceTree = "<group>"; };
+		16A8F33324BA382D000EEB6A /* Goal+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Goal+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		16A8F33A24BA399F000EEB6A /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
+		16A8F33F24BA3E67000EEB6A /* MockPersistentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPersistentContainer.swift; sourceTree = "<group>"; };
+		16A8F34124BA4608000EEB6A /* FluidService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluidService.swift; sourceTree = "<group>"; };
+		16A8F34524BA48B0000EEB6A /* FluidServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluidServiceTests.swift; sourceTree = "<group>"; };
+		16A8F34724BA4E54000EEB6A /* GoalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalService.swift; sourceTree = "<group>"; };
+		16A8F34924BA4E62000EEB6A /* IntakeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntakeService.swift; sourceTree = "<group>"; };
+		16A8F34B24BA5785000EEB6A /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		16A8F34D24BA5FFB000EEB6A /* GoalServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalServiceTests.swift; sourceTree = "<group>"; };
 		B31AA1C424734EAB007708F4 /* WaterLogging.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WaterLogging.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B31AA1C724734EAB007708F4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B31AA1C924734EAB007708F4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -64,6 +102,67 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		160FA67824BA7D4600AE21F0 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				160FA67924BA7D5E00AE21F0 /* BannerNotificationView.swift */,
+				160FA67B24BA873600AE21F0 /* CircularProgressView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		16A8F32924BA3609000EEB6A /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				16A8F32C24BA363D000EEB6A /* ManagedObjects */,
+				16A8F32A24BA3632000EEB6A /* CoreDataStack.swift */,
+			);
+			path = Persistence;
+			sourceTree = "<group>";
+		};
+		16A8F32C24BA363D000EEB6A /* ManagedObjects */ = {
+			isa = PBXGroup;
+			children = (
+				16A8F32E24BA382D000EEB6A /* Intake+CoreDataClass.swift */,
+				16A8F32F24BA382D000EEB6A /* Intake+CoreDataProperties.swift */,
+				16A8F33024BA382D000EEB6A /* Fluid+CoreDataClass.swift */,
+				16A8F33124BA382D000EEB6A /* Fluid+CoreDataProperties.swift */,
+				16A8F33224BA382D000EEB6A /* Goal+CoreDataClass.swift */,
+				16A8F33324BA382D000EEB6A /* Goal+CoreDataProperties.swift */,
+			);
+			path = ManagedObjects;
+			sourceTree = "<group>";
+		};
+		16A8F32D24BA3725000EEB6A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				16A8F33A24BA399F000EEB6A /* UserDefaults.swift */,
+				16A8F34B24BA5785000EEB6A /* Date.swift */,
+				160FA67D24BCB93D00AE21F0 /* CoreDataStack+Seedable.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		16A8F34324BA47D4000EEB6A /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				16A8F34124BA4608000EEB6A /* FluidService.swift */,
+				16A8F34724BA4E54000EEB6A /* GoalService.swift */,
+				16A8F34924BA4E62000EEB6A /* IntakeService.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		16A8F34424BA47E0000EEB6A /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				16A8F34524BA48B0000EEB6A /* FluidServiceTests.swift */,
+				16A8F34D24BA5FFB000EEB6A /* GoalServiceTests.swift */,
+				160FA67624BA750B00AE21F0 /* IntakeServiceTests.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 		B31AA1BB24734EAA007708F4 = {
 			isa = PBXGroup;
 			children = (
@@ -85,6 +184,10 @@
 		B31AA1C624734EAB007708F4 /* WaterLogging */ = {
 			isa = PBXGroup;
 			children = (
+				160FA67824BA7D4600AE21F0 /* View */,
+				16A8F34324BA47D4000EEB6A /* Service */,
+				16A8F32D24BA3725000EEB6A /* Extensions */,
+				16A8F32924BA3609000EEB6A /* Persistence */,
 				B31AA1C724734EAB007708F4 /* AppDelegate.swift */,
 				B31AA1F024734F10007708F4 /* AppTabBarController.swift */,
 				B31AA1C924734EAB007708F4 /* SceneDelegate.swift */,
@@ -102,6 +205,8 @@
 		B31AA1E024734EAC007708F4 /* WaterLoggingTests */ = {
 			isa = PBXGroup;
 			children = (
+				16A8F33F24BA3E67000EEB6A /* MockPersistentContainer.swift */,
+				16A8F34424BA47E0000EEB6A /* Service */,
 				B31AA1E124734EAC007708F4 /* WaterLoggingTests.swift */,
 				B31AA1E324734EAC007708F4 /* Info.plist */,
 			);
@@ -209,11 +314,26 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				160FA67A24BA7D5E00AE21F0 /* BannerNotificationView.swift in Sources */,
+				16A8F34824BA4E54000EEB6A /* GoalService.swift in Sources */,
+				16A8F32B24BA3632000EEB6A /* CoreDataStack.swift in Sources */,
 				B31AA1ED24734EC7007708F4 /* TrackWaterViewController.swift in Sources */,
+				16A8F34224BA4608000EEB6A /* FluidService.swift in Sources */,
+				16A8F33824BA382D000EEB6A /* Goal+CoreDataClass.swift in Sources */,
 				B31AA1EF24734EE8007708F4 /* VisualizeWaterIntakeViewController.swift in Sources */,
+				16A8F33524BA382D000EEB6A /* Intake+CoreDataProperties.swift in Sources */,
+				16A8F34C24BA5785000EEB6A /* Date.swift in Sources */,
+				16A8F34A24BA4E62000EEB6A /* IntakeService.swift in Sources */,
 				B31AA1F124734F10007708F4 /* AppTabBarController.swift in Sources */,
 				B31AA1C824734EAB007708F4 /* AppDelegate.swift in Sources */,
+				16A8F33624BA382D000EEB6A /* Fluid+CoreDataClass.swift in Sources */,
+				16A8F33924BA382D000EEB6A /* Goal+CoreDataProperties.swift in Sources */,
+				16A8F33724BA382D000EEB6A /* Fluid+CoreDataProperties.swift in Sources */,
+				16A8F33424BA382D000EEB6A /* Intake+CoreDataClass.swift in Sources */,
+				160FA67E24BCB93D00AE21F0 /* CoreDataStack+Seedable.swift in Sources */,
 				B31AA1CA24734EAB007708F4 /* SceneDelegate.swift in Sources */,
+				16A8F33B24BA399F000EEB6A /* UserDefaults.swift in Sources */,
+				160FA67C24BA873600AE21F0 /* CircularProgressView.swift in Sources */,
 				B31AA1D224734EAB007708F4 /* WaterLogging.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -222,7 +342,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				16A8F34024BA3E67000EEB6A /* MockPersistentContainer.swift in Sources */,
 				B31AA1E224734EAC007708F4 /* WaterLoggingTests.swift in Sources */,
+				16A8F34624BA48B0000EEB6A /* FluidServiceTests.swift in Sources */,
+				16A8F34E24BA5FFB000EEB6A /* GoalServiceTests.swift in Sources */,
+				160FA67724BA750B00AE21F0 /* IntakeServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WaterLogging/AppDelegate.swift
+++ b/WaterLogging/AppDelegate.swift
@@ -15,6 +15,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        guard !isRunningUnitTests else {
+            window = nil
+            return true
+        }
+        
+        configurePersistentStore()
         
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = UINavigationController(rootViewController: AppTabBarController())
@@ -38,6 +44,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // MARK: - Core Data stack
+
+    func configurePersistentStore() {
+        CoreDataStack.shared.persistentContainer = persistentContainer
+        
+        if !UserDefaults.dataStoreWasSeeded {
+            CoreDataStack.shared.seedData() { success in
+                UserDefaults.dataStoreWasSeeded = true
+            }
+        }
+    }
 
     lazy var persistentContainer: NSPersistentContainer = {
         /*
@@ -65,22 +81,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         })
         return container
     }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
+    
+    private var isRunningUnitTests: Bool {
+        ProcessInfo.processInfo.environment.keys.contains("XCInjectBundleInto")
     }
-
 }
 

--- a/WaterLogging/Extensions/CoreDataStack+Seedable.swift
+++ b/WaterLogging/Extensions/CoreDataStack+Seedable.swift
@@ -1,0 +1,39 @@
+//
+//  CoreDataStack+Seedable.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/13/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import Foundation
+
+extension CoreDataStack: Seedable {
+    func seedData(completion: ((Bool) -> Void)? = nil) {
+        let context = mainContext
+        
+        let water = Fluid(context: context)
+        water.name = "Water"
+        water.index = 0
+        water.waterBase = 1
+
+        let tea = Fluid(context: context)
+        tea.name = "Tea"
+        tea.index = 1
+        tea.waterBase = 1
+
+        let coffee = Fluid(context: context)
+        coffee.name = "Coffee"
+        coffee.index = 2
+        coffee.waterBase = 0.98
+
+        let juice = Fluid(context: context)
+        juice.name = "Juice"
+        juice.index = 3
+        juice.waterBase = 0.85
+
+        saveContext()
+        
+        completion?(true)
+    }
+}

--- a/WaterLogging/Extensions/Date.swift
+++ b/WaterLogging/Extensions/Date.swift
@@ -1,0 +1,23 @@
+//
+//  Date.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import Foundation
+
+extension Date {
+    var startOfDay: Date {
+        Calendar.current.startOfDay(for: self)
+    }
+    
+    var tomorrow: Date {
+        Calendar.current.date(byAdding: .day, value: 1, to: startOfDay)!
+    }
+    
+    var yesterday: Date {
+        Calendar.current.date(byAdding: .second, value: -1, to: startOfDay)!
+    }
+}

--- a/WaterLogging/Extensions/UserDefaults.swift
+++ b/WaterLogging/Extensions/UserDefaults.swift
@@ -1,0 +1,22 @@
+//
+//  UserDefaults.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import Foundation
+
+extension UserDefaults {
+
+    struct Key {
+        static let dataStoreWasSeeded = "dataStoreWasSeeded"
+    }
+    
+    static var dataStoreWasSeeded: Bool {
+        set { UserDefaults.standard.set(newValue, forKey: Key.dataStoreWasSeeded) }
+        get { UserDefaults.standard.bool(forKey: Key.dataStoreWasSeeded) }
+    }
+
+}

--- a/WaterLogging/Persistence/CoreDataStack.swift
+++ b/WaterLogging/Persistence/CoreDataStack.swift
@@ -1,0 +1,68 @@
+//
+//  CoreDataStack.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import CoreData
+
+protocol Seedable {
+    func seedData(completion: ((Bool) -> Void)?)
+}
+
+class CoreDataStack {
+    static let shared = CoreDataStack()
+
+    var mainContext: NSManagedObjectContext {
+        persistentContainer.viewContext
+    }
+
+    var persistentContainer: NSPersistentContainer!
+    
+    // MARK: - Fetch
+
+    func fetch<T: NSFetchRequestResult>(_ request: NSFetchRequest<T>) throws -> [T] {
+        return try mainContext.fetch(request)
+    }
+    
+    // MARK: - Saving
+
+    func saveContext () {
+        let context = mainContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+        
+    // MARK: - Clearing CoreData objects
+    
+    public func clearAllCoreData() {
+        let entities = self.persistentContainer.managedObjectModel.entities
+        entities.compactMap({ $0.name }).forEach {
+            self.clearDeepObject(for: $0)
+        }
+    }
+
+    public func clearDeepObject(for entity: String) {
+        let context = mainContext
+
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entity)
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+
+        do {
+            try context.execute(deleteRequest)
+            try context.save()
+        } catch {
+            print ("There was an error removing data for entity: \(entity)")
+        }
+    }
+}

--- a/WaterLogging/Persistence/ManagedObjects/Fluid+CoreDataClass.swift
+++ b/WaterLogging/Persistence/ManagedObjects/Fluid+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  Fluid+CoreDataClass.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Fluid)
+public class Fluid: NSManagedObject {
+
+}

--- a/WaterLogging/Persistence/ManagedObjects/Fluid+CoreDataProperties.swift
+++ b/WaterLogging/Persistence/ManagedObjects/Fluid+CoreDataProperties.swift
@@ -1,0 +1,42 @@
+//
+//  Fluid+CoreDataProperties.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Fluid {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Fluid> {
+        return NSFetchRequest<Fluid>(entityName: "Fluid")
+    }
+
+    @NSManaged public var index: Int16
+    @NSManaged public var name: String
+    @NSManaged public var waterBase: Double
+    @NSManaged public var intakes: NSSet?
+
+}
+
+// MARK: Generated accessors for intakes
+extension Fluid {
+
+    @objc(addIntakesObject:)
+    @NSManaged public func addToIntakes(_ value: Intake)
+
+    @objc(removeIntakesObject:)
+    @NSManaged public func removeFromIntakes(_ value: Intake)
+
+    @objc(addIntakes:)
+    @NSManaged public func addToIntakes(_ values: NSSet)
+
+    @objc(removeIntakes:)
+    @NSManaged public func removeFromIntakes(_ values: NSSet)
+
+}

--- a/WaterLogging/Persistence/ManagedObjects/Goal+CoreDataClass.swift
+++ b/WaterLogging/Persistence/ManagedObjects/Goal+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  Goal+CoreDataClass.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Goal)
+public class Goal: NSManagedObject {
+
+}

--- a/WaterLogging/Persistence/ManagedObjects/Goal+CoreDataProperties.swift
+++ b/WaterLogging/Persistence/ManagedObjects/Goal+CoreDataProperties.swift
@@ -1,0 +1,24 @@
+//
+//  Goal+CoreDataProperties.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Goal {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Goal> {
+        return NSFetchRequest<Goal>(entityName: "Goal")
+    }
+
+    @NSManaged public var amount: Double
+    @NSManaged public var startDate: Date
+    @NSManaged public var endDate: Date?
+
+}

--- a/WaterLogging/Persistence/ManagedObjects/Intake+CoreDataClass.swift
+++ b/WaterLogging/Persistence/ManagedObjects/Intake+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  Intake+CoreDataClass.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Intake)
+public class Intake: NSManagedObject {
+
+}

--- a/WaterLogging/Persistence/ManagedObjects/Intake+CoreDataProperties.swift
+++ b/WaterLogging/Persistence/ManagedObjects/Intake+CoreDataProperties.swift
@@ -1,0 +1,25 @@
+//
+//  Intake+CoreDataProperties.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Intake {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Intake> {
+        return NSFetchRequest<Intake>(entityName: "Intake")
+    }
+
+    @NSManaged public var volume: Double
+    @NSManaged public var waterVolume: Double
+    @NSManaged public var date: Date
+    @NSManaged public var fluid: Fluid
+
+}

--- a/WaterLogging/SceneDelegate.swift
+++ b/WaterLogging/SceneDelegate.swift
@@ -48,7 +48,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+        CoreDataStack.shared.saveContext()
     }
 
 

--- a/WaterLogging/Service/FluidService.swift
+++ b/WaterLogging/Service/FluidService.swift
@@ -1,0 +1,23 @@
+//
+//  FluidService.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import CoreData
+
+protocol FluidService {
+    func fetchAll() -> [Fluid]
+}
+
+struct CoreDataFluidService: FluidService {    
+    func fetchAll() -> [Fluid] {
+        let request: NSFetchRequest<Fluid> = Fluid.fetchRequest()
+        let sortIndexAscending = NSSortDescriptor(key: "index", ascending: true)
+        request.sortDescriptors = [sortIndexAscending]
+        let result = try? CoreDataStack.shared.fetch(request)
+        return result ?? []
+    }
+}

--- a/WaterLogging/Service/GoalService.swift
+++ b/WaterLogging/Service/GoalService.swift
@@ -1,0 +1,101 @@
+//
+//  GoalService.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import CoreData
+
+protocol GoalService {
+    var currentGoal: Goal? { get }
+    func endGoal(_ goal: Goal, on date: Date)
+    func goalStarted(on date: Date) -> Goal?
+    @discardableResult func updateGoal(amount: Double) throws -> Goal
+    @discardableResult func createGoal(amount: Double, startDate: Date) throws -> Goal
+}
+
+struct CoreDataGoalService {
+    // MARK: - CoreDataStack Helpers
+    
+    private var context: NSManagedObjectContext {
+        CoreDataStack.shared.mainContext
+    }
+    
+    private func save() {
+        CoreDataStack.shared.saveContext()
+    }
+}
+
+extension CoreDataGoalService: GoalService {
+ 
+    enum Error: Swift.Error {
+        case duplicateStartDate
+    }
+    
+    var currentGoal: Goal? {
+        let request: NSFetchRequest<Goal> = Goal.fetchRequest()
+        request.predicate = NSPredicate(format: "endDate == nil")
+        
+        guard let goals = try? CoreDataStack.shared.fetch(request) else {
+            return nil
+        }
+        
+        return goals.first
+    }
+    
+    func goalStarted(on date: Date) -> Goal? {
+        let request: NSFetchRequest<Goal> = Goal.fetchRequest()
+        request.predicate = NSPredicate(format: "startDate >= %@ && startDate < %@",
+                                        date.startOfDay as NSDate,
+                                        date.tomorrow as NSDate)
+        
+        guard let goals = try? CoreDataStack.shared.fetch(request) else {
+            return nil
+        }
+
+        return goals.first
+    }
+    
+    @discardableResult
+    func createGoal(amount: Double, startDate: Date = Date()) throws -> Goal {
+        guard goalStarted(on: startDate) == nil else {
+            throw Error.duplicateStartDate
+        }
+        
+        if let currentGoal = self.currentGoal {
+            endGoal(currentGoal)
+        }
+        
+        let today = Calendar.current.startOfDay(for: startDate)
+
+        let goal = Goal(context: context)
+        goal.startDate = today
+        goal.amount = amount
+        
+        save()
+        
+        return goal
+    }
+    
+    @discardableResult
+    func updateGoal(amount: Double) throws -> Goal {
+        guard let goal = currentGoal else {
+            return try createGoal(amount: amount)
+        }
+        
+        if Calendar.current.isDateInToday(goal.startDate) {
+            goal.amount = amount
+            save()
+            return goal
+        } else {
+            return try createGoal(amount: amount)
+        }
+    }
+    
+    func endGoal(_ goal: Goal, on date: Date = Date().yesterday) {
+        goal.endDate = date
+        save()
+    }
+}

--- a/WaterLogging/Service/IntakeService.swift
+++ b/WaterLogging/Service/IntakeService.swift
@@ -1,0 +1,77 @@
+//
+//  IntakeService.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import CoreData
+
+protocol IntakeService {
+    func totalIntakeForToday() -> Double
+    func totalIntake(for date: Date) -> Double
+    @discardableResult func addIntakeToday(volume: Double, fluid: Fluid) -> Intake
+    @discardableResult func addIntake(volume: Double, fluid: Fluid, on date: Date) -> Intake
+}
+
+struct CoreDataIntakeService {
+    // MARK: - CoreDataStack Helpers
+    
+    private var context: NSManagedObjectContext {
+        CoreDataStack.shared.mainContext
+    }
+    
+    private func save() {
+        CoreDataStack.shared.saveContext()
+    }
+}
+
+extension CoreDataIntakeService: IntakeService {
+    
+    func totalIntakeForToday() -> Double {
+        return totalIntake(for: Date())
+    }
+    
+    func totalIntake(for date: Date) -> Double {
+        let totalIntakeKey = "totalIntake"
+        
+        let expressionDesc = NSExpressionDescription()
+        expressionDesc.name = totalIntakeKey
+        expressionDesc.expression = NSExpression(forKeyPath: "@sum.waterVolume")
+        expressionDesc.expressionResultType = .doubleAttributeType;
+        
+        let request: NSFetchRequest<NSFetchRequestResult> = Intake.fetchRequest()
+        request.resultType = .dictionaryResultType
+        request.propertiesToFetch = [expressionDesc]
+        request.predicate = NSPredicate(format: "date >= %@ && date < %@",
+                                        date.startOfDay as NSDate,
+                                        date.tomorrow as NSDate)
+
+        guard let result = try? CoreDataStack.shared.fetch(request),
+              let dict = result.first as? [String: Double],
+              let total = dict[totalIntakeKey] else {
+            return 0
+        }
+        return total
+    }
+    
+    @discardableResult
+    func addIntakeToday(volume: Double, fluid: Fluid) -> Intake {
+        return addIntake(volume: volume, fluid: fluid, on: Date())
+    }
+    
+    @discardableResult
+    func addIntake(volume: Double, fluid: Fluid, on date: Date) -> Intake {
+        let intake = Intake(context: context)
+        intake.date = date
+        intake.fluid = fluid
+        intake.volume = volume
+        intake.waterVolume = volume * fluid.waterBase
+
+        save()
+        
+        return intake
+    }
+
+}

--- a/WaterLogging/TrackWaterViewController.swift
+++ b/WaterLogging/TrackWaterViewController.swift
@@ -8,8 +8,14 @@ import UIKit
 
 class TrackWaterViewController: UIViewController {
     
+    private let goalService: GoalService = CoreDataGoalService()
+    private let fluidService: FluidService = CoreDataFluidService()
+    private let intakeService: IntakeService = CoreDataIntakeService()
+    private var fluids: [Fluid]!
+    
     private let addWaterButton = UIButton()
     private let updateGoalButton = UIButton()
+    private let notificationView = BannerNotificationView()
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -23,8 +29,9 @@ class TrackWaterViewController: UIViewController {
     // Set Up
     
     private func setUp() {
-        addWaterButton.setTitle("Add 8 oz Water", for: .normal)
+        addWaterButton.setTitle("Add Intake", for: .normal)
         updateGoalButton.setTitle("Update Daily Goal", for: .normal)
+        
         addWaterButton.addTarget(self, action: #selector(addWaterButtonPressed), for: .touchUpInside)
         updateGoalButton.addTarget(self, action: #selector(goalButtonPressed), for: .touchUpInside)
         
@@ -36,9 +43,20 @@ class TrackWaterViewController: UIViewController {
     }
     
     private func setUpConstraints() {
+        
+        notificationView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(notificationView)
+        NSLayoutConstraint.activate([notificationView.topAnchor.constraint(equalTo: view.topAnchor),
+                                     notificationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                                     notificationView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                                     notificationView.heightAnchor.constraint(equalToConstant: 60)])
+        
+        
         let container = UIView()
+    
         addWaterButton.translatesAutoresizingMaskIntoConstraints = false
         updateGoalButton.translatesAutoresizingMaskIntoConstraints = false
+        
         container.addSubview(addWaterButton)
         container.addSubview(updateGoalButton)
         container.translatesAutoresizingMaskIntoConstraints = false
@@ -46,6 +64,7 @@ class TrackWaterViewController: UIViewController {
         view.addSubview(container)
         
         // Buttons constraints
+        
         let addWaterButtonConstraints = [addWaterButton.topAnchor.constraint(equalTo: container.topAnchor),
                                          addWaterButton.leadingAnchor.constraint(equalTo: container.leadingAnchor),
                                          addWaterButton.trailingAnchor.constraint(equalTo: container.trailingAnchor),]
@@ -71,17 +90,123 @@ class TrackWaterViewController: UIViewController {
         NSLayoutConstraint.activate(containerConstraints)
         
     }
+
+    // MARK: - Forms
     
-    // Actions
+    func presentGoalForm() {
+        let alert = UIAlertController(title: "Update Daily Goal",
+                                      message: "You should drink about 0.7 ounces of water for every pound you weigh.",
+                                      preferredStyle: .alert)
+
+        alert.addTextField { (textField) in
+            textField.placeholder = "Ounces"
+            textField.keyboardType = .decimalPad
+        }
+
+        alert.addAction(UIAlertAction(title: "Save", style: .default) { action in
+            self.updateGoal(value: alert.textFields?.first?.text)
+        })
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        
+        present(alert, animated: true, completion: nil)
+    }
+    
+    func presentIntakeForm() {
+        loadFluids()
+
+        let message = """
+         Select a liquid and enter the total number of ounces consumed.
+         Note: While other liquids can help you reach your daily intake goal, but make sure to watch out for those added sugars. Looking at you, fruit juice.
+         \n\n\n\n\n\n\n
+         """
+        let alertView = UIAlertController(
+            title: "Add Intake",
+            message: message,
+            preferredStyle: .alert)
+
+        let pickerView = UIPickerView(frame: CGRect(x: 0, y: 120, width: 260, height: 162))
+        pickerView.dataSource = self
+        pickerView.delegate = self
+        pickerView.alpha = 0
+
+        alertView.view.addSubview(pickerView)
+        alertView.addTextField { (textField) in
+            textField.keyboardType = .decimalPad
+            textField.placeholder = "Total ounces"
+        }
+        alertView.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler:nil))
+        alertView.addAction(UIAlertAction(title: "Ok", style: .default, handler:{ (UIAlertAction) in
+            self.addIntake(volume: Double(alertView.textFields?.first?.text ?? "") ?? -1,
+                           fluid: self.fluids[pickerView.selectedRow(inComponent: 0)])
+        }))
+        
+        present(alertView, animated: true) {
+            pickerView.frame.size.width = alertView.view.frame.size.width
+            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 0.2, delay: 0, options: [.curveLinear], animations: {
+              pickerView.alpha = 1
+            })
+        }
+    }
+    
+    // MARK: - Services
+    
+    func loadFluids() {
+        if fluids == nil {
+            fluids = fluidService.fetchAll()
+        }
+    }
+    
+    func updateGoal(value: String?) {
+        guard let value = value,
+              let amount = Double(value) else {
+                notificationView.flashError(message: "Error updating daily goal")
+                return
+        }
+        
+        guard let goal = try? goalService.updateGoal(amount: amount) else {
+            notificationView.flashError(message: "Error updating goal")
+            return
+        }
+        
+        notificationView.flashSuccess(message: "New daily goal set: \(String(format: "%.2f", goal.amount))oz.")
+    }
+    
+    func addIntake(volume: Double, fluid: Fluid) {
+        guard volume > 0 else {
+            notificationView.flashError(message: "Intake volume must be greater than zero")
+            return
+        }
+        let intake = intakeService.addIntakeToday(volume: volume, fluid: fluid)
+        notificationView.flashSuccess(message: "Added \(intake.volume)oz of \(intake.fluid.name)")
+    }
+    
+    
+    // MARK: - Actions
     
     @objc private func addWaterButtonPressed() {
-        print("Add water button pressed")
+        presentIntakeForm()
     }
     
     @objc private func goalButtonPressed() {
-        print("Goal button pressed")
+        presentGoalForm()
     }
-    
 
 }
 
+extension TrackWaterViewController: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return fluids.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        let fluid = fluids[row]
+        return "\(fluid.name) (\(Int(fluid.waterBase * 100))% h2o)"
+    }
+}
+
+extension TrackWaterViewController: UIPickerViewDelegate { }

--- a/WaterLogging/View/BannerNotificationView.swift
+++ b/WaterLogging/View/BannerNotificationView.swift
@@ -1,0 +1,75 @@
+//
+//  BannerNotificationView.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import UIKit
+
+class BannerNotificationView: UIView {
+
+    private let label = UILabel()
+    private var isActive = false
+    private var fadeOutAnimator: UIViewPropertyAnimator?
+    
+    init() {
+        super.init(frame: .zero)
+        setUp()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUp() {
+        alpha = 0
+        
+        setUpConstraints()
+    }
+    
+    private func setUpConstraints() {
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        
+        NSLayoutConstraint.activate(
+            [label.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 5),
+             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10)] )
+    }
+    
+    func flashSuccess(message: String) {
+        label.text = message
+        backgroundColor = .green
+        flash()
+    }
+    
+    func flashError(message: String) {
+        label.text = message
+        backgroundColor = .red
+        flash()
+    }
+    
+    private func flash() {
+        if !isActive {
+            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 1.0, delay: 0, options: [.curveEaseOut], animations: {
+                self.alpha = 1.0
+            })
+            isActive = true
+        }
+
+        scheduleFadeOut(delay: 3)
+    }
+    
+    private func scheduleFadeOut(delay: TimeInterval) {
+        fadeOutAnimator?.stopAnimation(true)
+        fadeOutAnimator = UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 1.0, delay: delay, options: [.curveLinear], animations: {
+          self.alpha = 0.0
+        }) { position in
+            self.isActive = false
+        }
+    }
+
+}

--- a/WaterLogging/View/CircularProgressView.swift
+++ b/WaterLogging/View/CircularProgressView.swift
@@ -1,0 +1,74 @@
+//
+//  CircularProgressView.swift
+//  WaterLogging
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import UIKit
+
+class CircularProgressView: UIView {
+    
+    let progressBarLayer = CAShapeLayer()
+    var currentProgress: Double = 0
+    var progressColor: CGColor = UIColor.blue.cgColor {
+        didSet {
+            progressBarLayer.strokeColor = progressColor
+            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 1.2, delay: 0, options: [.curveLinear], animations: {
+                self.progressBarLayer.strokeColor = self.progressColor
+            })
+        }
+    }
+    
+    func removeAllSublayers() {
+        layer.sublayers?.forEach { layer in
+            layer.removeFromSuperlayer()
+        }
+    }
+
+    override func layoutSubviews() {
+        let radius = frame.size.width / 2
+        
+        guard radius > 0 else { return }
+        
+        removeAllSublayers()
+        
+        let circularPath = UIBezierPath(arcCenter: CGPoint(x: radius, y: radius),
+                                        radius: radius,
+                                        startAngle: -0.5 * CGFloat.pi,
+                                        endAngle: 1.5 * CGFloat.pi,
+                                        clockwise: true)
+        
+        let track = CAShapeLayer()
+        track.path = circularPath.cgPath
+        track.strokeColor = UIColor.lightGray.cgColor
+        track.lineWidth = 20
+        track.fillColor = UIColor.clear.cgColor
+        track.lineCap = CAShapeLayerLineCap.round
+        layer.addSublayer(track)
+        
+        progressBarLayer.path = circularPath.cgPath
+        progressBarLayer.strokeColor = self.progressColor
+        progressBarLayer.lineWidth = 20
+        progressBarLayer.fillColor = UIColor.clear.cgColor
+        progressBarLayer.lineCap = CAShapeLayerLineCap.round
+        progressBarLayer.strokeEnd = 0
+        
+        layer.addSublayer(progressBarLayer)
+    }
+    
+    func animate(to progress: Double) {
+        let animation = CABasicAnimation(keyPath: "strokeEnd")
+        animation.fromValue = currentProgress
+        animation.toValue = progress
+        animation.duration = 1.5
+        animation.fillMode = CAMediaTimingFillMode.forwards
+        animation.isRemovedOnCompletion = false
+        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        
+        progressBarLayer.add(animation, forKey: "progress")
+        
+        currentProgress = min(max(progress, 0), 1)
+    }
+}

--- a/WaterLogging/VisualizeWaterIntakeViewController.swift
+++ b/WaterLogging/VisualizeWaterIntakeViewController.swift
@@ -8,7 +8,11 @@ import UIKit
 
 class VisualizeWaterIntakeViewController: UIViewController {
 
+    private let goalService: GoalService = CoreDataGoalService()
+    private let intakeService: IntakeService = CoreDataIntakeService()
+    
     private let trackingLabel = UILabel()
+    private let progressView = CircularProgressView()
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -18,37 +22,84 @@ class VisualizeWaterIntakeViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view.
-    }
-    
+
     // Set Up
 
     private func setUp() {
-        trackingLabel.text = "X oz of X oz goal consumed today"
+        view.addSubview(progressView)
         trackingLabel.textColor = .label
+        trackingLabel.numberOfLines = 0
+        trackingLabel.textAlignment = .center
         view.backgroundColor = .systemBackground
+        
+        view.addSubview(trackingLabel)
+        progressView.setNeedsLayout()
         
         setUpConstraints()
     }
-    
+
     private func setUpConstraints() {
         trackingLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(trackingLabel)
         
         // Label constraints
         
         let trackingLabelConstraints = [trackingLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-                                    trackingLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
-                                    trackingLabel.topAnchor.constraint(greaterThanOrEqualTo: self.view.topAnchor),
-                                    trackingLabel.leadingAnchor.constraint(greaterThanOrEqualTo: self.view.leadingAnchor),
-                                    trackingLabel.trailingAnchor.constraint(lessThanOrEqualTo: self.view.trailingAnchor),
-                                    trackingLabel.bottomAnchor.constraint(lessThanOrEqualTo: self.view.bottomAnchor)]
+                                        trackingLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+                                        trackingLabel.topAnchor.constraint(greaterThanOrEqualTo: self.view.topAnchor),
+                                        trackingLabel.leadingAnchor.constraint(greaterThanOrEqualTo: self.view.leadingAnchor),
+                                        trackingLabel.trailingAnchor.constraint(lessThanOrEqualTo: self.view.trailingAnchor),
+                                        trackingLabel.bottomAnchor.constraint(lessThanOrEqualTo: self.view.bottomAnchor)
+                                        ]
         
         NSLayoutConstraint.activate(trackingLabelConstraints)
         
+        // Progress Bar constraints
+        
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        let progressBarConstraints = [progressView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                                      progressView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+                                      progressView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 50),
+                                      progressView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -50),
+                                      progressView.heightAnchor.constraint(equalTo: progressView.widthAnchor)
+                                      ]
+        
+        
+        NSLayoutConstraint.activate(progressBarConstraints)
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        updateVisualization()
+    }
+    
+    private func color(for progress: Double) -> CGColor {
+        let color: UIColor
+        if progress >= 1 {
+            color = .blue
+        } else if progress > 0.7 {
+            color = .green
+        } else if progress > 0.5 {
+            color = .yellow
+        } else {
+            color = .red
+        }
+        
+        return color.cgColor
+    }
+    
+    private func updateVisualization() {
+        let amount = intakeService.totalIntakeForToday()
+        if let goal = goalService.currentGoal?.amount {
+            trackingLabel.text = "\(String(format: "%.2f", amount))oz of \(goal)oz\nconsumed today"
+            let progress = amount / goal
+            progressView.progressColor = color(for: progress)
+            progressView.animate(to: progress)
+        } else {
+            trackingLabel.text = "\(amount)oz\nconsumed today"
+            progressView.animate(to: 0)
+        }
     }
 }
 

--- a/WaterLogging/WaterLogging.xcdatamodeld/WaterLogging.xcdatamodel/contents
+++ b/WaterLogging/WaterLogging.xcdatamodeld/WaterLogging.xcdatamodel/contents
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E195" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E287" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Fluid" representedClassName="Fluid" syncable="YES">
+        <attribute name="index" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="waterBase" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="intakes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Intake" inverseName="fluid" inverseEntity="Intake"/>
+    </entity>
+    <entity name="Goal" representedClassName="Goal" syncable="YES">
+        <attribute name="amount" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="startDate" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="Intake" representedClassName="Intake" syncable="YES">
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="volume" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="waterVolume" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="fluid" maxCount="1" deletionRule="Nullify" destinationEntity="Fluid" inverseName="intakes" inverseEntity="Fluid"/>
+    </entity>
+    <elements>
+        <element name="Goal" positionX="-63" positionY="-18" width="128" height="88"/>
+        <element name="Intake" positionX="-54" positionY="18" width="128" height="103"/>
+        <element name="Fluid" positionX="-36" positionY="45" width="128" height="103"/>
+    </elements>
 </model>

--- a/WaterLoggingTests/MockPersistentContainer.swift
+++ b/WaterLoggingTests/MockPersistentContainer.swift
@@ -1,0 +1,35 @@
+//
+//  MockPersistentContainer.swift
+//  WaterLoggingTests
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import CoreData
+@testable import WaterLogging
+
+func configurePersistentStore() {
+    CoreDataStack.shared.persistentContainer = mockPersistantContainer
+    CoreDataStack.shared.seedData()
+}
+
+func clearPersistentStore() {
+    CoreDataStack.shared.persistentContainer = nil
+}
+
+var mockPersistantContainer: NSPersistentContainer {
+    let container = NSPersistentContainer(name: "WaterLogging")
+    let description = NSPersistentStoreDescription()
+    description.shouldAddStoreAsynchronously = false
+    description.url = URL(fileURLWithPath: "/dev/null")
+    container.persistentStoreDescriptions = [description]
+
+    container.loadPersistentStores { (description, error) in
+        precondition( description.type == NSSQLiteStoreType )
+        if let error = error {
+            fatalError("failed to create in memory container \(error)")
+        }
+    }
+    return container
+}

--- a/WaterLoggingTests/Service/FluidServiceTests.swift
+++ b/WaterLoggingTests/Service/FluidServiceTests.swift
@@ -1,0 +1,38 @@
+//
+//  FluidServiceTests.swift
+//  WaterLoggingTests
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import XCTest
+@testable import WaterLogging
+
+class FluidServiceTests: XCTestCase {
+    
+    var fluidService: FluidService = CoreDataFluidService()
+
+    override func setUpWithError() throws {
+        configurePersistentStore()
+    }
+
+    override func tearDownWithError() throws {
+        clearPersistentStore()
+    }
+
+    func test_fetchAll_returnsFluidsOrderedByIndex() throws {
+        let fluids = fluidService.fetchAll()
+        let indecies = fluids.map { $0.index }
+
+        XCTAssertEqual(indecies , [0,1,2,3])
+    }
+    
+    func test_orderedFluidsHaveCorrectNames() throws {
+        let fluids = fluidService.fetchAll()
+        let names = fluids.map { $0.name }
+
+        XCTAssertEqual(names,  ["Water", "Tea", "Coffee", "Juice"])
+    }
+
+}

--- a/WaterLoggingTests/Service/GoalServiceTests.swift
+++ b/WaterLoggingTests/Service/GoalServiceTests.swift
@@ -1,0 +1,44 @@
+//
+//  GoalServiceTests.swift
+//  WaterLoggingTests
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import XCTest
+@testable import WaterLogging
+
+class GoalServiceTests: XCTestCase {
+    
+    var goalService: GoalService = CoreDataGoalService()
+
+    override func setUpWithError() throws {
+        configurePersistentStore()
+    }
+
+    override func tearDownWithError() throws {
+        clearPersistentStore()
+    }
+    
+    func test_createGoal_newGoalHasNoEndDate() throws {
+        let goal = try! goalService.createGoal(amount: 100, startDate: Date())
+
+        XCTAssertNil(goal.endDate)
+    }
+    
+    func test_createGoal_willFailToCreateGoalsWithADuplicateStartDate() throws {
+        try! goalService.createGoal(amount: 100, startDate: Date())
+        XCTAssertThrowsError(try goalService.createGoal(amount: 100, startDate: Date()))
+    }
+    
+    func test_updateGoal_willEndAnExistingGoalIfStartDateIsNotToday() throws {
+        try! goalService.createGoal(amount: 100, startDate: Date().yesterday)
+        try! goalService.updateGoal(amount: 120)
+        
+        let yesterdayGoal = goalService.goalStarted(on: Date().yesterday)
+
+        XCTAssert(Calendar.current.isDateInYesterday(yesterdayGoal!.endDate!))
+    }
+
+}

--- a/WaterLoggingTests/Service/IntakeServiceTests.swift
+++ b/WaterLoggingTests/Service/IntakeServiceTests.swift
@@ -1,0 +1,46 @@
+//
+//  IntakeServiceTests.swift
+//  WaterLoggingTests
+//
+//  Created by Jacob Bullock on 7/11/20.
+//  Copyright © 2020 Apple. All rights reserved.
+//
+
+import XCTest
+@testable import WaterLogging
+
+class IntakeServiceTests: XCTestCase {
+    
+    var intakeService: IntakeService = CoreDataIntakeService()
+    var fluidService: FluidService = CoreDataFluidService()
+
+    override func setUp() {
+        configurePersistentStore()
+    }
+
+    override func tearDownWithError() throws {
+        clearPersistentStore()
+    }
+    
+    func test_totalIntakeForToday_willCalculateComputedVolumeCorrectlyForWater() throws {
+        let water = fluidService.fetchAll().first!
+        intakeService.addIntakeToday(volume: 20, fluid: water)
+        intakeService.addIntakeToday(volume: 20, fluid: water)
+        intakeService.addIntake(volume: 20, fluid: water, on: Date().yesterday)
+        
+        let total = intakeService.totalIntakeForToday()
+        XCTAssertEqual(Int(total), 40)
+    }
+    
+    func test_totalIntakeForToday_willCalculateComputedVolumeCorrectlyForJuice() throws {
+        let juice = fluidService.fetchAll().last!
+        intakeService.addIntakeToday(volume: 30, fluid: juice)
+        intakeService.addIntakeToday(volume: 20, fluid: juice)
+        intakeService.addIntake(volume: 20, fluid: juice, on: Date().yesterday)
+        
+        let total = intakeService.totalIntakeForToday()
+        let expectation = Int(50.0 * juice.waterBase)
+        XCTAssertEqual(Int(total), expectation)
+    }
+
+}


### PR DESCRIPTION
This is the same information that's in the `README`:

## WaterLogging

## Managed Objects
`Goal`: I designed goals so that they can have a start and end date. If you update your goal, and the goal's start date is different than today, it will set the current goals' end date to yesterday and create a new goal with a new start date of today.  The idea behind this strategy was to make it so that if other features were added to the app that required us to see how many days a user met their daily goal, we'd want the check to reflect the goal of those specific days. There are some checks to make sure that there can't be two goals with the same start date. 

`Fluid`: I added a `Fluid` entity as part of the enhancement for tracking different types of intake and calculating the total water consumption based on how much water makes up each fluid.  There is currently no methods for adding new `Fluid`s, but the necessary fluids for the enhancement are seeded when the core data stack is configured. 

`Intake`: Intake is used to track the individual entries for a user's fluid consumption.  The intake has a date, amount, volume, and a waterVolume.  In order to make using the database to run various mathematical operations, I figured it'd be better to store the computed water volume since that value wouldn't change, but would need to be calculated every time it was needed and the calculation would have to reach into the `Fluid` relationship

The `Intake` has no direct relationship to a `Goal`. You can add an `Intake` without having set a `Goal` at all.  If we wanted to pull a goal for a specific intake or get all intakes of a specific goal, I think we could use a `FetchedProperty` for that, currently you'd have to pull those values by using dates.

The `Intake` has a required relationship to a `Fluid`.  Technically this relationship doesn't need to be required in the current state of the app because we are calculating the `waterVolume` when we create a new `Intake`, but thinking ahead to other features that might get added in app like this, we might want to see percentage of intakes that were of a specific fluid and the relationship would be needed there.

## Persistence
For simplicity, I made a singleton (_gasp_) to manage the CoreDataStack. The container can be configured separately for unit testing and the main app.
There is an extension to seed the database with some `Fluid`s as described in the enhancement for keeping track of different types of drinks.

## Service
There is a `Service` for each of the Managed Objects described above. The services are instantiated as needed by the view controllers that use them. Each service has a protocol defining the methods and a concrete implementation coupled to core data. The services reaches into the `CoreDataStack` to execute fetch requests as well as basic CRUD on the entities.

## Track
In the Track ViewController, I added a couple of alerts to allow user entry as well as show some feedback when the user tries to add an intake or update a goal.  There is a simple `BannerNotificationView` that will flash green or red with a message depending if the operation was a success or failure so there is some feedback to the user when submitting the forms.

For updating a goal there is a UIAlertController with a textfield to enter the new value.

For adding an intake I used another UIAlertController and swizzled it give me enough room to add a picker in the view.  This allows the user to select a Fluid and enter the number of ounces consumed. Any respectable dev would have done this by presenting a view controller, but I was trying to be mindful of the allotted time. The other UX I had started for selecting a liquid seemed odd as it was disjointed from entering the number of ounces, so I combined that here. 

## Visualize
For the Visualization ViewController I updated the data to render every time the user goes to that tab.
The UI will support a user not having set a daily goal and will instead just show the total number of ounces consumed that day.
I also added a circular progress bar for some extra flair. 

## Testing
There are a handful of tests written focused around the service layer.  With more time I would have added more for the ViewControllers to make sure things like the text on the visualization tab was correct and created some other doubles to ensure things like the notification messages were correct.

The CoreDataStack persistent container is setup and torn down for each test.
